### PR TITLE
Feat: add rate limiter middleware to control API request rates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	golang.org/x/sys v0.25.0
 	gorm.io/gorm v1.25.12
 	k8s.io/apimachinery v0.31.1
+	golang.org/x/time v0.6.0
 )
 
 require (
@@ -85,7 +86,6 @@ require (
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/text v0.18.0 // indirect
-	golang.org/x/time v0.6.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/internal/init/router/router.go
+++ b/internal/init/router/router.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"log"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	echoMiddleware "github.com/labstack/echo/v4/middleware"
@@ -32,9 +31,6 @@ func Routers() *echo.Echo {
 	// TODO: Add this middleware for log and debug
 	Router.Use(echoMiddleware.Logger())
 	Router.Use(echoMiddleware.Recover())
-
-	// rate limiter middleware
-	Router.Use(middleware.RateLimiter(5, 30*time.Second)) // 5 requests per 30 seconds
 
 	setStatic(Router)
 

--- a/internal/init/router/router.go
+++ b/internal/init/router/router.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"log"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	echoMiddleware "github.com/labstack/echo/v4/middleware"
@@ -31,6 +32,9 @@ func Routers() *echo.Echo {
 	// TODO: Add this middleware for log and debug
 	Router.Use(echoMiddleware.Logger())
 	Router.Use(echoMiddleware.Recover())
+
+	// rate limiter middleware
+	Router.Use(middleware.RateLimiter(5, 30*time.Second)) // 5 requests per 30 seconds
 
 	setStatic(Router)
 

--- a/internal/middleware/rate_limiter.go
+++ b/internal/middleware/rate_limiter.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"golang.org/x/time/rate"
+)
+
+func RateLimiter(maxRequests int, duration time.Duration) echo.MiddlewareFunc {
+	// Create a map to hold rate limiters for each IP
+	var visitors = make(map[string]*rate.Limiter)
+	var mutex sync.Mutex
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ip := c.RealIP()
+
+			// Lock the map to avoid race conditions
+			mutex.Lock()
+			if _, exists := visitors[ip]; !exists {
+				visitors[ip] = rate.NewLimiter(rate.Every(duration), maxRequests)
+			}
+
+			limiter := visitors[ip]
+			mutex.Unlock()
+
+			if !limiter.Allow() {
+				return c.JSON(http.StatusTooManyRequests, map[string]string{
+					"error": "Too many requests",
+				})
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/internal/router/router_base.go
+++ b/internal/router/router_base.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"time"
+
 	"github.com/labstack/echo/v4"
 	apiV1 "github.com/sail-host/cloud/internal/app/api/v1"
 	"github.com/sail-host/cloud/internal/middleware"
@@ -11,6 +13,9 @@ type BaseRouter struct {
 
 func (r *BaseRouter) InitRouter(Router *echo.Group) {
 	baseRouter := Router.Group("/auth")
+
+	baseRouter.Use(middleware.RateLimiter(5, 30*time.Second)) // 5 requests per 30 seconds
+
 	baseApi := apiV1.ApiGroupApp.BaseApi
 	{
 		baseRouter.POST("/login", baseApi.Login)


### PR DESCRIPTION
- Implemented RateLimiter middleware to limit the number of requests per client IP within a specified duration
- Added in-memory rate limiter using "golang.org/x/time/rate" package
- Ensured thread-safe access to rate limiter map using a mutex
- Responds with 429 status code when request limit is exceeded